### PR TITLE
Comfort 600

### DIFF
--- a/custom_components/nilan_cts600/nilan_cts600.py
+++ b/custom_components/nilan_cts600/nilan_cts600.py
@@ -453,10 +453,10 @@ class CTS600:
                     display = run_action(e['display']) if 'display' in e else self.display()
                     # print (f"scan: {e}, disp {display}")
                     if 'regexp' in e:
-                        if not (match := re.match (e['regexp'], display)):
+                        if not (match := re.match (e['regexp'], display)) and ('default' not in e):
                             break # Stop sequence at first mismatch
                         else:
-                            record_matching_entry (match.groupdict(), e)
+                            record_matching_entry (match.groupdict() if match else { 'value': e['default'] }, e)
                             if 'gonext' in e:
                                 run_action(e['gonext'])
                 else:
@@ -504,6 +504,7 @@ class CTS600:
             f (regexp="(?P<value>.*)", var='display', parse=lambda d: d.replace ('/', '\n')),
             f (regexp=".* (?P<value>\d+)°C", var='thermostat', parse=int),
             f (regexp="^(?P<value>\w+)", var='mode'),
+            f (regexp="^\w+\s+(?P<value>\w)", var='program', default=None),
             f (regexp=".*>(?P<value>\d+)<", var='flow', parse=int)
         ]
         if updateShowData:

--- a/custom_components/nilan_cts600/nilan_cts600.py
+++ b/custom_components/nilan_cts600/nilan_cts600.py
@@ -502,7 +502,7 @@ class CTS600:
         scan_menu = [
             _scanner_reset_menu(),
             f (regexp="(?P<value>.*)", var='display', parse=lambda d: d.replace ('/', '\n')),
-            f (regexp=".* (?P<value>\d+)°C", var='thermostat', parse=int),
+            f (regexp=".* (?P<value>\d+)°C", var='thermostat', parse=int, kind='temperature'),
             f (regexp="^(?P<value>\w+)", var='mode'),
             f (regexp="^\w+\s+(?P<value>\w)", var='program', default=None),
             f (regexp=".*>(?P<value>\d+)<", var='flow', parse=int)


### PR DESCRIPTION
Added support for Comfort 600 which uses other temperature sensors than VPL-15. Implemented automatic sensor discovery to support all ventilation units using the CTS 600 control unit. The changes are backwards compatible, so it should not have any impact on the existing support for VPL-15 other than new sensors will be added. Existing sensors (previously hardcoded for VPL-15) will have unchanged key/name and hence history data will be preserved.

There are still changes to come to address slight variance in the way the control is implemented for the different ventilation units. However, the integration is now fully working and tested on Comfort 600.